### PR TITLE
debian: set systemd default.target to graphical

### DIFF
--- a/blueprint/debian/plugin.sh
+++ b/blueprint/debian/plugin.sh
@@ -83,9 +83,8 @@ EOF
     # disable any default.target
     # (LXC template symlinks to multi-user.target by default)
     SYSTEMD_DEFAULT_TARGET="${rootfs}/etc/systemd/system/default.target"
-    if [ -e "$SYSTEMD_DEFAULT_TARGET" ] ; then
-        rm "$SYSTEMD_DEFAULT_TARGET"
-    fi
+    rm -f "$SYSTEMD_DEFAULT_TARGET"
+    ln -s "/lib/systemd/system/graphical.target" "$SYSTEMD_DEFAULT_TARGET"
 
     export DEBIAN_FRONTEND=noninteractive
     export DEBCONF_NONINTERACTIVE_SEEN=true


### PR DESCRIPTION
This explicitly sets the systemd default.target symlink to point to
graphical.target.

This also fixes a previous bug with the "-e" file check that always
returned false even if default.target existed since it was being run
from outside the chroot. This would result in the container booting into
multi-user.target (set by LXC during lxc-create), not starting up the
display manager, and resulting in blank HDMI display output.