### PR TITLE
docs: show root requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ See blueprint/debian as the canonical example for Debian.
 
 Build a Debian Jessie armhf container called 'debian' (option defaults):
 
-    $ ./build.sh
+    # ./build.sh
 
 Build a Debian Jessie arm64 container called 'jessie64':
 
-    $ ./build.sh -b debian -n jessie64 -- -a arm64
+    # ./build.sh -b debian -n jessie64 -- -a arm64
 
 *Tip: You will need root privileges to mount binfmt_misc for bootstrapping
 foreign architecture containers.*


### PR DESCRIPTION
Normally # indicates a root shell, $ indicates non-root.
I just ran build.sh, it fails without root.

    $ ./build.sh
    update-binfmts: warning: unable to open /proc/sys/fs/binfmt_misc/status for writing: Permission denied
    --> loading distro plugin...
    [ DEBIAN ] loading...
    --> building image...
    [ DEBIAN ] bootstrapping rootfs...
    lxc-create: conf.c: chown_mapped_root: 3478 No mapping for container root
    lxc-create: lxccontainer.c: do_bdev_create: 1054 Error chowning /home/ian/.local/share/lxc/debian/rootfs to container root
    lxc-create: conf.c: suggest_default_idmap: 4594 You must either run as root, or define uid mappings
    lxc-create: conf.c: suggest_default_idmap: 4595 To pass uid mappings to lxc-create, you could create
    lxc-create: conf.c: suggest_default_idmap: 4596 ~/.config/lxc/default.conf:
    lxc-create: conf.c: suggest_default_idmap: 4597 lxc.include = /etc/lxc/default.conf
    lxc-create: conf.c: suggest_default_idmap: 4598 lxc.id_map = u 0 100000 65536
    lxc-create: conf.c: suggest_default_idmap: 4599 lxc.id_map = g 0 100000 65536
    lxc-create: lxccontainer.c: do_lxcapi_create: 1518 Error creating backing store type (none) for debian
    lxc-create: tools/lxc_create.c: main: 318 Error creating container debian
    --> cleaning up...
    rm: cannot remove 'maru_0.1-1_all.deb': No such file or directory
    make: [clean] Error 1 (ignored)


Signed-off-by: Ian Kelling <ian@iankelling.org>