### PR TITLE
Enable dynamic input switching

### DIFF
--- a/blueprint/debian/debpkg/DEBIAN/control
+++ b/blueprint/debian/debpkg/DEBIAN/control
@@ -8,7 +8,7 @@ Depends: libc6,
     lightdm,
     dbus-x11,
     xfce4, tango-icon-theme,
-    sudo, rsync,
+    sudo, rsync, xinput,
     maru-mflinger-client
 Recommends: xfce4-terminal, xfce4-screenshooter,
     lxtask,

--- a/blueprint/debian/debpkg/etc/maruos/disable-input
+++ b/blueprint/debian/debpkg/etc/maruos/disable-input
@@ -1,0 +1,9 @@
+#!/bin/bash
+uname=$(/usr/bin/getent passwd 901000 | /usr/bin/cut -f1 -d:)
+export DISPLAY=:0.0
+export XAUTHORITY=/home/$uname/.Xauthority
+ids=$(/usr/bin/xinput list --id-only)
+while [[ -z "$ids" ]];do
+    ids=$(/usr/bin/xinput list --id-only)
+done;
+for id in $ids;do /usr/bin/xinput disable $id;done

--- a/blueprint/debian/debpkg/etc/maruos/enable-input
+++ b/blueprint/debian/debpkg/etc/maruos/enable-input
@@ -1,0 +1,9 @@
+#!/bin/bash
+uname=$(/usr/bin/getent passwd 901000 | /usr/bin/cut -f1 -d:)
+export DISPLAY=:0.0
+export XAUTHORITY=/home/$uname/.Xauthority
+ids=$(/usr/bin/xinput list --id-only)
+while [[ -z "$ids" ]];do
+    ids=$(/usr/bin/xinput list --id-only)
+done;
+for id in $ids;do /usr/bin/xinput enable $id;done


### PR DESCRIPTION
The `blueprints` part to enable dynamic input switching. For the whose view, please visit the issue [Enable dynamic input switching](https://github.com/maruos/maruos/issues/97).