### PR TITLE
build: Use stretch to replace latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ services:
 
 script:
     - ./build-with-docker.sh
+    - ./build-with-docker.sh -b debian -n stretch-container -- -r stretch -a arm64 --minimal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:latest
+FROM debian:stretch
 
 RUN apt-get update && apt-get install -y \
     binfmt-support \


### PR DESCRIPTION
Now `debian:latest` is `debian:stretch` in docker, but it will be `debian:buster` someday later, which upgrades lxc to 3.x. The lxc 3.x changes some config item name, and it will cause building error because of old config. So just holding debian in `stretch` before we are ready to upgrade lxc to 3.x.