### PR TITLE
Split blueprints building with different travis instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ services:
     - docker
 
 script:
-    - ./build-with-docker.sh
     - ./build-with-docker.sh -b debian -n buster-container -- -r buster -a arm64 --minimal
+    - ./build-with-docker.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 os: linux
+dist: focal
 
 services:
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
 os: linux
 dist: focal
 
+env:
+    - CIINSTALL=yes MARUARCH=1
+    - CIINSTALL=yes MARUARCH=2
 services:
     - docker
 
 script:
-    - ./build-with-docker.sh -b debian -n buster-container -- -r buster -a arm64 --minimal
-    - ./build-with-docker.sh
+    - if [[ $MARUARCH -eq 1 ]]; then
+        ./build-with-docker.sh;
+      fi;
+    - if [[ $MARUARCH -eq 2 ]]; then
+        ./build-with-docker.sh -b debian -n buster-container -- -r buster -a arm64 --minimal;
+      fi;


### PR DESCRIPTION
With some unknown reason, if we run armhf building firstly and then arm64 building, the arm64 building will fail with qemu segment fault; if we run arm64 building firstly, and then armhf building, the armhf building with fail with some unknown reason. So this CL will split building with different travis instances, and one instance for one building.