### PR TITLE
Add ubuntu key server as download link for lxc-create

### DIFF
--- a/blueprint/debian/plugin.sh
+++ b/blueprint/debian/plugin.sh
@@ -52,6 +52,7 @@ bootstrap () {
 
     pecho "bootstrapping rootfs..."
     mkdir -p "$rootfs"
+    DOWNLOAD_KEYSERVER="keyserver.ubuntu.com" \
     lxc-create -t download -n "$name" --dir "$rootfs" -- \
         --dist debian --arch "$arch" --release "$release"
 }


### PR DESCRIPTION
It can help us to avoid "lxc-create -t download : unable ERROR: Unable to fetch GPG key from keyserver".